### PR TITLE
[Feature] 카카오맵 현 위치 기능 추가

### DIFF
--- a/src/apis/boothDetail.js
+++ b/src/apis/boothDetail.js
@@ -2,6 +2,7 @@ import { instance } from "./instance";
 export const getBoothDetail = async ({ booth_id }) => {
   try {
     const res = await instance.get(`api/v1/booth/detail/${booth_id}`);
+    console.log(res);
     return res;
   } catch (err) {
     console.log(err);

--- a/src/pages/booth/Styled.js
+++ b/src/pages/booth/Styled.js
@@ -57,6 +57,14 @@ export const Header = styled.div`
   width: 100%;
 `;
 
+export const CurrentLocationButton = styled.div`
+  display: flex;
+  position: absolute;
+  z-index: 20;
+  bottom: 80px;
+  left: 10px;
+`;
+
 export const DateSelector = styled.div`
   display: flex;
   align-items: center;
@@ -111,10 +119,10 @@ export const BoothListWrapper = styled.div`
   flex-direction: column;
   position: fixed;
   padding: 1rem;
-  bottom: ${({ $isOpen }) => ($isOpen ? '0' : '-140px')};
+  bottom: ${({ $isOpen }) => ($isOpen ? '0' : '-20px')};
   width: 100%;
   max-width: 540px;
-  height: ${({ $isOpen }) => ($isOpen ? '400px' : '200px')};
+  height: ${({ $isOpen }) => ($isOpen ? '350px' : '0px')};
   background-color: inherit;
   transition: bottom 0.5s ease, height 0.5s ease;
   z-index: 10;
@@ -171,8 +179,8 @@ export const FilterItem = styled.div`
 
   border-radius: ${({ $isOpen }) => $isOpen ? '8.55px 8.55px 0 0' : '8.55px'}; 
   
-  background-color: ${({ selected, theme }) => selected ? theme.colors.confirmButton : '#FFFFFF'};
-  color: ${({ selected, theme }) => (selected ? '#FFFFFF' : theme.colors.fall)};
+  background-color: ${({ $selected, theme }) => $selected ? theme.colors.confirmButton : '#FFFFFF'};
+  color: ${({ $selected, theme }) => ($selected ? '#FFFFFF' : theme.colors.fall)};
 
   cursor: pointer;
   width: 62px;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,17 +1,10 @@
 import { defineConfig } from "vite";
-import fs from 'fs';
 import react from "@vitejs/plugin-react";
 import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  server: {
-    https: {
-      key: fs.readFileSync(path.resolve(__dirname, 'localhost-key.pem')),
-      cert: fs.readFileSync(path.resolve(__dirname, 'localhost.pem')),
-    },
-  },
   resolve: {
     alias: {
       "@atoms": path.resolve(__dirname, "src/atoms"),

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,17 @@
 import { defineConfig } from "vite";
+import fs from 'fs';
 import react from "@vitejs/plugin-react";
 import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    https: {
+      key: fs.readFileSync(path.resolve(__dirname, 'localhost-key.pem')),
+      cert: fs.readFileSync(path.resolve(__dirname, 'localhost.pem')),
+    },
+  },
   resolve: {
     alias: {
       "@atoms": path.resolve(__dirname, "src/atoms"),


### PR DESCRIPTION
## 🔍 What is the PR?

- 현위치 보기 기능 (좌측 아래 현위치 or 현위치 취소) 토글링 넣었습니다. 현위치(지금 위치 고정)
- 바텀 시트가 닫혔을 때 전체 안 보이도록 해두었습니다.
- 필터링 초기화를 눌렀을 때 filter dropdown도 꺼지도록 또, 한번에 하나의 필터 드롭다운만 활성화되도록 수정했습니다.
- 맵 정중앙에 학교가 오도록 수정했습니다.

## 📸 Screenshot

<img width="363" alt="image" src="https://github.com/user-attachments/assets/f7ca002d-db31-4666-a374-2b2caa34389d">

## 📍 PR Point

현위치 보기 기능을 껐다 켰다하여 사용성 좋게 만들어 보았습니다 !
마커 디자인. 현위치 보기 버튼 디자인이 추가로 필요합니다.. ㅎ

## 📢 Notices

geoloaction을 사용해서 실시간 경도 위도를 받아왔는데 이 경우 https에서만 사용이 가능합니다.
localhost에서 이를 테스트하고 싶으시다면 아래 것 따라해주세요.

먼저 https를 위한 인증서를 발급받고 작업중인 폴더 안에 넣어주세요.

`# mkcert 설치
brew install mkcert

# 로컬 인증서 설치
mkcert -install

# 인증서 생성 (localhost용)
mkcert localhost`


vite.config.js에 fs를 import해서 펨키를 넣어줍니다.
plugins: [react()],
밑에 넣어주세요

`/server: {
    https: {
      key: fs.readFileSync(path.resolve(__dirname, 'localhost-key.pem')),
      cert: fs.readFileSync(path.resolve(__dirname, 'localhost.pem')),
    },
  },
`

해당 팸키는 절대 git에 올리시면 안됩니다 !!
테스트 후 삭제하시거나 commit할 때 절대 올라가지 않도록 주의해주세요.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

#4 
